### PR TITLE
setup tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 .Python
-bin/
-include/
-lib/
-share/
-src/
+*.swp
+*.swo
 *.pyc
+*.pyo
+/*.egg-info
+/.tox
+/build
+/dist

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This library is distributed as 'fluent-logger' python package. Please execute th
 
     $ pip install fluent-logger
 
+On Python 2.5, you have to install 'simplejson' in addition.
+
 ## Configuration
 
 Fluent daemon must be lauched with the following configuration:

--- a/fluent/handler.py
+++ b/fluent/handler.py
@@ -4,7 +4,11 @@ import sys, urllib
 import msgpack
 import socket
 import threading
-import json
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
 
 from fluent import sender
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,11 @@
 #!/usr/bin/python
 
-from distutils.core import setup
 from os import path
+
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 README = path.abspath(path.join(path.dirname(__file__), 'README.md'))
 desc = 'A Python logging handler for Fluentd event collector'
@@ -24,5 +28,6 @@ setup(
     'Programming Language :: Python :: 3',
     'Development Status :: 4 - Beta',
     'Intended Audience :: Developers',
-  ]
+  ],
+  test_suite='tests'
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+[tox]
+envlist = py25, py26, py27
+
+[testenv]
+commands=python setup.py test
+
+[testenv:py25]
+deps = simplejson
+
+[testenv:py26]
+
+[testenv:py27]


### PR DESCRIPTION
Setup [tox](http://pypi.python.org/pypi/tox) to test cross python versions. Currently, python versions of 2.5, 2.6 and 2.7 are supported.

If you have already installed `tox` and these python versions, you can run tests by following single command.

```
tox
```
