### PR TITLE
support python 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ Many web/mobile applications generate huge amount of event logs (c,f. login, log
 
 **fluent-logger-python** is a Python library, to record the events from Python application.
 
+## Requirements
+
+* Python 2.6 or greater including 3.x
+
 ## Installation
 
 This library is distributed as 'fluent-logger' python package. Please execute the following command to install it.
 
     $ pip install fluent-logger
-
-On Python 2.5, you have to install 'simplejson' in addition.
 
 ## Configuration
 

--- a/fluent/handler.py
+++ b/fluent/handler.py
@@ -1,6 +1,6 @@
 import logging
 import os
-import sys, urllib
+import sys
 import msgpack
 import socket
 import threading

--- a/fluent/sender.py
+++ b/fluent/sender.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 import msgpack
 import socket
 import threading
@@ -57,7 +58,7 @@ class FluentSender(object):
             tag = self.tag
         packet = (tag, timestamp, data)
         if self.verbose:
-            print packet
+            print(packet)
         return self.packer.pack(packet)
 
     def _send(self, bytes):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,3 @@
-import sys
-sys.path = ['..'] + sys.path
-
-from test_event import *
-from test_sender import *
-from test_handler import *
+from tests.test_event import *
+from tests.test_sender import *
+from tests.test_handler import *

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -1,8 +1,12 @@
 import socket
 import threading
 import time
-from cStringIO import StringIO
 from msgpack import Unpacker
+
+try:
+    from cStringIO import StringIO as BytesIO
+except ImportError:
+    from io import BytesIO
 
 class MockRecvServer(threading.Thread):
     """
@@ -11,7 +15,7 @@ class MockRecvServer(threading.Thread):
     def __init__(self, port):
         self._sock = socket.socket()
         self._sock.bind(('localhost', port))
-        self._buf = StringIO()
+        self._buf = BytesIO()
 
         threading.Thread.__init__(self)
         self.start()
@@ -36,4 +40,5 @@ class MockRecvServer(threading.Thread):
     def get_recieved(self):
         self.wait()
         self._buf.seek(0)
-        return list(Unpacker(self._buf))
+        # TODO: have to process string encoding properly. currently we assume that all encoding is utf-8.
+        return list(Unpacker(self._buf, encoding='utf-8'))

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -1,5 +1,5 @@
 import unittest
-import mockserver
+from tests import mockserver
 import logging
 import fluent.handler
 import msgpack
@@ -7,12 +7,12 @@ import msgpack
 class TestLogger(unittest.TestCase):
     def setUp(self):
         super(TestLogger, self).setUp()
-        for port in xrange(10000, 20000):
+        for port in range(10000, 20000):
             try:
                 self._server = mockserver.MockRecvServer(port)
                 self._port = port
                 break
-            except IOError, e:
+            except IOError as e:
                 pass
 
     def get_data(self):

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -1,17 +1,18 @@
+from __future__ import print_function
 import unittest
-import mockserver
+from tests import mockserver
 import fluent.sender
 import msgpack
 
 class TestSender(unittest.TestCase):
     def setUp(self):
         super(TestSender, self).setUp()
-        for port in xrange(10000, 20000):
+        for port in range(10000, 20000):
             try:
                 self._server = mockserver.MockRecvServer(port)
                 break
-            except IOError, e:
-                print e
+            except IOError as e:
+                print(e)
                 pass
         self._sender = fluent.sender.FluentSender(
                 tag='test',

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,14 @@
 [tox]
-envlist = py25, py26, py27
+envlist = py26, py27, py32
 
 [testenv]
 commands=python setup.py test
 
-[testenv:py25]
-deps = simplejson
-
 [testenv:py26]
+basepython = python2.6
 
 [testenv:py27]
+basepython = python2.7
+
+[testenv:py32]
+basepython = python3.2


### PR DESCRIPTION
Please support Python 3.x.

Unfortunately, this pull req will effect fluent-logger-python to lose compatibility with Python versions prior than 2.5.
