### PR TITLE
Fix config in readme: 'tcp' input is obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,12 +19,14 @@ This library is distributed as 'fluent-logger' python package. Please execute th
 
 ## Configuration
 
-Fluentd daemon must be lauched with the following configuration:
+Fluentd daemon must be launched with a tcp source configuration:
 
     <source>
       type forward
       port 24224
     </source>
+
+To quickly test your setup, add a matcher that logs to the stdout:
 
     <match app.**>
       type stdout

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This library is distributed as 'fluent-logger' python package. Please execute th
 Fluentd daemon must be lauched with the following configuration:
 
     <source>
-      type tcp
+      type forward
       port 24224
     </source>
 


### PR DESCRIPTION
This patch fixes the following warning I got when launching td-agent with the configuration supplied in README:

```
2013-12-09 19:51:56 +0900 [warn]: 'tcp' input is obsoleted and will be removed soon. Use 'forward' instead.
```

I also took the liberty of splitting the sample config into two parts: the source directive and the match directive. As far as I understand, the match directive isn't really a must to make this library work and therefore the README was a little misleading in saying "fluentd must be launched with the following config..."