### PR TITLE
AttributeError: 'module' object has no attribute 'JSONDecodeError'

### DIFF
--- a/fluent/handler.py
+++ b/fluent/handler.py
@@ -38,7 +38,7 @@ class FluentRecordFormatter(object):
         elif isinstance(msg, str):
             try:
                 self._add_dic(data, json.loads(str(msg)))
-            except (ValueError, json.JSONDecodeError):
+            except ValueError:
                 pass
 
     @staticmethod


### PR DESCRIPTION
There is no JSONDecodeError class in built-in json (at least for me on Python 2.7.5). It is only present in simplejson, but in simplejson it's a subclass of ValueError so removing it from the tuple of exception classes doesn't change the behaviour.