### PR TITLE
Allow formatter customizations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.2"
   - "3.3"

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ This client-library also has FluentHandler class for Python logging module.
     
     logging.basicConfig(level=logging.INFO)
     l = logging.getLogger('fluent.test')
-    l.addHandler(handler.FluentHandler('app.follow', host='host', port=24224))
+    h = handler.FluentHandler('app.follow', host='host', port=24224)
+    h.setFormatter(handler.FluentRecordFormatter())
+    l.addHandler(h)
     l.info({
       'from': 'userA',
       'to': 'userB'

--- a/fluent/handler.py
+++ b/fluent/handler.py
@@ -56,7 +56,9 @@ class FluentRecordFormatter(logging.Formatter, object):
             try:
                 self._add_dic(data, json.loads(str(msg)))
             except ValueError:
-                pass
+                self._add_dic(data, {'message': msg})
+        else:
+            self._add_dic(data, {'message': msg})
 
     @staticmethod
     def _add_dic(data, dic):

--- a/fluent/handler.py
+++ b/fluent/handler.py
@@ -50,6 +50,14 @@ class FluentRecordFormatter(logging.Formatter, object):
         return data
 
     def _structuring(self, data, msg):
+        """ Melds `msg` into `data`.
+
+        :param data: dictionary to be sent to fluent server
+        :param msg: :class:`LogRecord`'s message to add to `data`.
+          `msg` can be a simple string for backward compatibility with
+          :mod:`logging` framework, a JSON encoded string or a dictionary
+          that will be merged into dictionary generated in :meth:`format.
+        """
         if isinstance(msg, dict):
             self._add_dic(data, msg)
         elif isinstance(msg, basestring):

--- a/fluent/handler.py
+++ b/fluent/handler.py
@@ -52,7 +52,7 @@ class FluentRecordFormatter(logging.Formatter, object):
     def _structuring(self, data, msg):
         if isinstance(msg, dict):
             self._add_dic(data, msg)
-        elif isinstance(msg, str):
+        elif isinstance(msg, basestring):
             try:
                 self._add_dic(data, json.loads(str(msg)))
             except ValueError:

--- a/fluent/handler.py
+++ b/fluent/handler.py
@@ -2,6 +2,7 @@
 
 import logging
 import socket
+import sys
 
 try:
     import simplejson as json
@@ -38,6 +39,10 @@ class FluentRecordFormatter(logging.Formatter, object):
         self.hostname = socket.gethostname()
 
     def format(self, record):
+        # Only needed for python2.6
+        if sys.version_info[0:2] <= (2, 6) and self.usesTime():
+            record.asctime = self.formatTime(record, self.datefmt)
+
         # Compute attributes handled by parent class.
         super(FluentRecordFormatter, self).format(record)
         # Add ours
@@ -48,6 +53,10 @@ class FluentRecordFormatter(logging.Formatter, object):
 
         self._structuring(data, record.msg)
         return data
+
+    def usesTime(self):
+        return any([value.find('%(asctime)') >= 0
+                    for value in self._fmt_dict.values()])
 
     def _structuring(self, data, msg):
         """ Melds `msg` into `data`.

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ desc = 'A Python logging handler for Fluentd event collector'
 
 setup(
   name='fluent-logger',
-  version='0.3.5',
+  version='0.4.0.dev',
   description=desc,
   long_description=open(README).read(),
   package_dir={'fluent': 'fluent'},

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -64,3 +64,44 @@ class TestHandler(unittest.TestCase):
         self.assertTrue('name' in data[0][2])
         self.assertEqual('fluent.test', data[0][2]['name'])
         self.assertTrue('lineno' in data[0][2])
+
+    def test_unstructured_message(self):
+        handler = fluent.handler.FluentHandler('app.follow', port=self._port)
+
+        logging.basicConfig(level=logging.INFO)
+        log = logging.getLogger('fluent.test')
+        handler.setFormatter(fluent.handler.FluentRecordFormatter())
+        log.addHandler(handler)
+        log.info('hello world')
+        handler.close()
+
+        data = self.get_data()
+        self.assertTrue('message' in data[0][2])
+        self.assertEqual('hello world', data[0][2]['message'])
+
+    def test_non_string_simple_message(self):
+        handler = fluent.handler.FluentHandler('app.follow', port=self._port)
+
+        logging.basicConfig(level=logging.INFO)
+        log = logging.getLogger('fluent.test')
+        handler.setFormatter(fluent.handler.FluentRecordFormatter())
+        log.addHandler(handler)
+        log.info(42)
+        handler.close()
+
+        data = self.get_data()
+        self.assertTrue('message' in data[0][2])
+
+    def test_non_string_dict_message(self):
+        handler = fluent.handler.FluentHandler('app.follow', port=self._port)
+
+        logging.basicConfig(level=logging.INFO)
+        log = logging.getLogger('fluent.test')
+        handler.setFormatter(fluent.handler.FluentRecordFormatter())
+        log.addHandler(handler)
+        log.info({42: 'root'})
+        handler.close()
+
+        data = self.get_data()
+        # For some reason, non-string keys are ignored
+        self.assertFalse(42 in data[0][2])

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -54,6 +54,7 @@ class TestHandler(unittest.TestCase):
             fluent.handler.FluentRecordFormatter(fmt={
                 'name': '%(name)s',
                 'lineno': '%(lineno)d',
+                'emitted_at': '%(asctime)s',
             })
         )
         log.addHandler(handler)
@@ -64,6 +65,7 @@ class TestHandler(unittest.TestCase):
         self.assertTrue('name' in data[0][2])
         self.assertEqual('fluent.test', data[0][2]['name'])
         self.assertTrue('lineno' in data[0][2])
+        self.assertTrue('emitted_at' in data[0][2])
 
     def test_unstructured_message(self):
         handler = fluent.handler.FluentHandler('app.follow', port=self._port)

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -44,3 +44,23 @@ class TestHandler(unittest.TestCase):
         eq('userB', data[0][2]['to'])
         self.assertTrue(data[0][1])
         self.assertTrue(isinstance(data[0][1], int))
+
+    def test_custom_fmt(self):
+        handler = fluent.handler.FluentHandler('app.follow', port=self._port)
+
+        logging.basicConfig(level=logging.INFO)
+        log = logging.getLogger('fluent.test')
+        handler.setFormatter(
+            fluent.handler.FluentRecordFormatter(fmt={
+                'name': '%(name)s',
+                'lineno': '%(lineno)d',
+            })
+        )
+        log.addHandler(handler)
+        log.info({'sample': 'value'})
+        handler.close()
+
+        data = self.get_data()
+        self.assertTrue('name' in data[0][2])
+        self.assertEqual('fluent.test', data[0][2]['name'])
+        self.assertTrue('lineno' in data[0][2])

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -67,6 +67,20 @@ class TestHandler(unittest.TestCase):
         self.assertTrue('lineno' in data[0][2])
         self.assertTrue('emitted_at' in data[0][2])
 
+    def test_json_encoded_message(self):
+        handler = fluent.handler.FluentHandler('app.follow', port=self._port)
+
+        logging.basicConfig(level=logging.INFO)
+        log = logging.getLogger('fluent.test')
+        handler.setFormatter(fluent.handler.FluentRecordFormatter())
+        log.addHandler(handler)
+        log.info('{"key": "hello world!", "param": "value"}')
+        handler.close()
+
+        data = self.get_data()
+        self.assertTrue('key' in data[0][2])
+        self.assertEqual('hello world!', data[0][2]['key'])
+
     def test_unstructured_message(self):
         handler = fluent.handler.FluentHandler('app.follow', port=self._port)
 


### PR DESCRIPTION
I am currently pursuing the goal of using fluent just like any other logging Handler/Formatter via `logging.config`

In order to do that I had to solve a couple of problems that make default FluentRecordFormatter not easy to deal with. It is now able to take a format argument which is a dictionary that holds keys and values. Values are regular `LogRecord` standard Python %-style mapping keys. The defaults are unchanged.

I also added a couple of fixes I found in other pull requests as I found them as well during my tests, so this should cover Issue #7, PR #8 and PR #16.

Finally I added a sphinx ready docstring to `FluentRecordFormatter._structuring` although this function could probably be merged in `format` directly since I don't see it used anywhere else.

Once merged, the following sample program:
```
import logging
from fluent.handler import FluentHandler, FluentRecordFormatter

logger = logging.getLogger('toto')
logger.setLevel(logging.DEBUG)
handler = FluentHandler('hello.test')
handler.setLevel(logging.DEBUG)
formatter = FluentRecordFormatter(fmt={
    'msg': '%(message)s',
    'level': '%(levelname)s',
    'hostname': '%(hostname)s',
})
handler.setFormatter(formatter)
logger.addHandler(handler)

logger.info('hel""lo')
```

logs

```
2014-08-01 13:59:05 +0200 hello.test: {"msg":"hel\"\"lo","message":"hel\"\"lo","hostname":"seta.local","level":"INFO"}
```

to fluentd.