### PR TITLE
Correct recommended fluentd configuration in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This library is distributed as 'fluent-logger' python package. Please execute th
 Fluentd daemon must be lauched with the following configuration:
 
     <source>
-      type tcp
+      type forward
       port 24224
     </source>
 


### PR DESCRIPTION
This just updates the README's suggested configuration for fluentd to use the forward input plugin instead of TCP.  Forward is actually what you want, TCP requires extra options and doesn't work out of the box with the example.