### PR TITLE
Save last_error on init and emit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ desc = 'A Python logging handler for Fluentd event collector'
 
 setup(
   name='fluent-logger',
-  version='0.3.5',
+  version='0.3.5-tophat1',
   description=desc,
   long_description=open(README).read(),
   package_dir={'fluent': 'fluent'},

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ desc = 'A Python logging handler for Fluentd event collector'
 
 setup(
   name='fluent-logger',
-  version='0.3.5-tophat1',
+  version='0.3.5',
   description=desc,
   long_description=open(README).read(),
   package_dir={'fluent': 'fluent'},

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -2,22 +2,58 @@
 
 import unittest
 
-from fluent import event, sender
+from mock import patch
 
+from fluent import event, sender
 
 sender.setup(server='localhost', tag='app')
 
 
 class TestEvent(unittest.TestCase):
     def test_logging(self):
+        # XXX: This tests succeeds even if the fluentd connection failed
+
         # send event with tag app.follow
         event.Event('follow', {
             'from': 'userA',
             'to':   'userB'
         })
 
+    def test_logging_with_timestamp(self):
+        # XXX: This tests succeeds even if the fluentd connection failed
+
         # send event with tag app.follow, with timestamp
         event.Event('follow', {
             'from': 'userA',
             'to':   'userB'
         }, time=int(0))
+
+    def test_no_last_error_on_successful_event(self):
+        global_sender = sender.get_global_sender()
+        event.Event('unfollow', {
+            'from': 'userC',
+            'to':   'userD'
+        })
+
+        # This test will fail unless you have a working connection to fluentd
+        self.assertEqual(global_sender.last_error, None)
+
+    @patch('fluent.sender.socket')
+    def test_connect_exception_during_event_send(self, mock_socket):
+        # Make the socket.socket().connect() call raise a custom exception
+        mock_connect = mock_socket.socket.return_value.connect
+        EXCEPTION_MSG = "a event send socket connect() exception"
+        mock_connect.side_effect = Exception(EXCEPTION_MSG)
+
+        # Force the socket to reconnect while trying to emit the event
+        global_sender = sender.get_global_sender()
+        global_sender._close()
+
+        event.Event('unfollow', {
+            'from': 'userE',
+            'to':   'userF'
+        })
+
+        ex = global_sender.last_error
+        self.assertEqual(ex.message, EXCEPTION_MSG)
+        global_sender.clear_last_error()

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -3,6 +3,8 @@
 from __future__ import print_function
 import unittest
 
+from mock import patch
+
 import fluent.sender
 
 from tests import mockserver
@@ -15,9 +17,21 @@ class TestSender(unittest.TestCase):
             try:
                 self._server = mockserver.MockRecvServer('localhost', port)
                 break
-            except IOError as exc:
-                print(exc)
+            # except IOError as exc:
+            #     print(exc)
+            except IOError:
+                pass
+        self.server_port = port
         self._sender = fluent.sender.FluentSender(tag='test', port=port)
+
+    def tearDown(self):
+        # Make sure that the mock server thread terminates after each test
+        sender = self._sender
+        sender.emit('foo', {'bar': 'baz'})
+        sender._close()
+        self.get_data()
+
+        sender.clear_errors_for_all_threads()
 
     def get_data(self):
         return self._server.get_recieved()
@@ -32,5 +46,41 @@ class TestSender(unittest.TestCase):
         eq(3, len(data[0]))
         eq('test.foo', data[0][0])
         eq({'bar': 'baz'}, data[0][2])
-        self.assertTrue(data[0][1])
-        self.assertTrue(isinstance(data[0][1], int))
+        self.assert_(data[0][1])
+        self.assert_(isinstance(data[0][1], int))
+
+    def test_no_last_error_on_successful_emit(self):
+        sender = self._sender
+        sender.emit('foo', {'bar': 'baz'})
+        sender._close()
+
+        self.assertEqual(sender.last_error, None)
+
+    def test_last_error_property(self):
+        sender = self._sender
+        EXCEPTION_MSG = "custom exception for testing last_error property"
+
+        sender.last_error = Exception(EXCEPTION_MSG)
+
+        self.assertEqual(sender.last_error.message, EXCEPTION_MSG)
+
+    def test_clear_last_error(self):
+        sender = self._sender
+        EXCEPTION_MSG = "custom exception for testing clear_last_error"
+        sender.last_error = Exception(EXCEPTION_MSG)
+
+        sender.clear_last_error()
+
+        self.assertEqual(sender.last_error, None)
+
+    @patch('fluent.sender.socket')
+    def test_connect_exception_during_sender_init(self, mock_socket):
+        # Make the socket.socket().connect() call raise a custom exception
+        mock_connect = mock_socket.socket.return_value.connect
+        EXCEPTION_MSG = "a sender init socket connect() exception"
+        mock_connect.side_effect = Exception(EXCEPTION_MSG)
+
+        sender = fluent.sender.FluentSender(tag='test', port=self.server_port)
+
+        ex = sender.last_error
+        self.assertEqual(ex.message, EXCEPTION_MSG)

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -31,8 +31,6 @@ class TestSender(unittest.TestCase):
         sender._close()
         self.get_data()
 
-        sender.clear_errors_for_all_threads()
-
     def get_data(self):
         return self._server.get_recieved()
 


### PR DESCRIPTION
Uses a threadlocal variable to store errors, which a user of this library can optionally access and act on after initializing the sender (initially connecting to the fluentd server) or emitting an event.

Also includes relevant tests.