### PR TITLE
Make FluentRecordFormatter functional for custom formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,38 @@ Then, please create the events like this. This will send the event to fluent, wi
 ### Python logging.Handler interface
 
 This client-library also has FluentHandler class for Python logging module.
+Custom default entries or [LogRecord attributes](https://docs.python.org/2/library/logging.html#logrecord-attributes) can be used when creating FORMAT dictionary.
 
     import logging
     from fluent import handler
-    
+
+    FORMAT = {
+        'host': socket.gethostname(),
+        'error_line': 'lineno',
+        'error_file': 'filename',
+        'code': 'levelno',
+        'type': 'levelname',
+        'logger': 'name',
+        'module': 'module',
+        'function_name': 'funcName',
+        'stack_trace': 'exc_info',
+        'message': 'msg'
+    }
+
+    formatter = handler.FluentRecordFormatter(FORMAT)
+    fluent_handler = handler.FluentHandler('app.follow', host='host', port=24224)
+    fluent_handler.setFormatter(formatter)
+
     logging.basicConfig(level=logging.INFO)
     l = logging.getLogger('fluent.test')
-    l.addHandler(handler.FluentHandler('app.follow', host='host', port=24224))
+    l.addHandler(fluent_handler)
+
+    l.info("This log entry will be logged with key: 'message'.")
     l.info({
       'from': 'userA',
       'to': 'userB'
     })
+    l.info('{"from": "userC", "to": "userD"}')
 
 ## Testing
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -27,20 +27,27 @@ class TestHandler(unittest.TestCase):
 
         logging.basicConfig(level=logging.INFO)
         log = logging.getLogger('fluent.test')
-        handler.setFormatter(fluent.handler.FluentRecordFormatter())
+        formatter = fluent.handler.FluentRecordFormatter()
+        handler.setFormatter(formatter)
         log.addHandler(handler)
         log.info({
             'from': 'userA',
             'to': 'userB'
         })
+        log.info('{"from": "userC", "to": "userD"}')
+        log.info("Test log message")
         handler.close()
 
         data = self.get_data()
         eq = self.assertEqual
-        eq(1, len(data))
+        eq(3, len(data))
         eq(3, len(data[0]))
         eq('app.follow', data[0][0])
         eq('userA', data[0][2]['from'])
         eq('userB', data[0][2]['to'])
+        eq('userC', data[1][2]['from'])
+        eq('userD', data[1][2]['to'])
+        eq('Test log message', data[2][2]['message'])
+        self.assertFalse(formatter.usesTime())
         self.assertTrue(data[0][1])
         self.assertTrue(isinstance(data[0][1], int))


### PR DESCRIPTION
FluentRecordFormatter cannot take custom formats as it is now. This is a fix on this, that allows custom formated log messages in order to avoid duplication in log messages.