### PR TITLE
fluent/fluent-logger-python should use its own account for travis-ci.org and coveralls.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 *.pyc
 *.pyo
 /*.egg-info
+/.coverage
+/.eggs
 /.tox
 /build
 /dist

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # A Python structured logger for Fluentd
 
-[![Build Status](https://travis-ci.org/EvaSDK/fluent-logger-python.svg?branch=master)](https://travis-ci.org/EvaSDK/fluent-logger-python)
-[![Coverage Status](https://coveralls.io/repos/EvaSDK/fluent-logger-python/badge.png)](https://coveralls.io/r/EvaSDK/fluent-logger-python)
+[![Build Status](https://travis-ci.org/fluent/fluent-logger-python.svg?branch=master)](https://travis-ci.org/fluent/fluent-logger-python)
+[![Coverage Status](https://coveralls.io/repos/fluent/fluent-logger-python/badge.svg)](https://coveralls.io/r/fluent/fluent-logger-python)
 
 Many web/mobile applications generate huge amount of event logs (c,f. login, logout, purchase, follow, etc). To analyze these event logs could be really valuable for improving the service. However, the challenge is collecting these logs easily and reliably.
 


### PR DESCRIPTION
The build status badges are linked to a fork of @EvaSDK and CI and coverage calculation aren't working on fluent/fluent-logger-python. This repo should setup its own accounts on travis-ci.org and coveralls.io.