### PR TITLE
Fix unstructured messages interpolation

### DIFF
--- a/fluent/handler.py
+++ b/fluent/handler.py
@@ -51,14 +51,14 @@ class FluentRecordFormatter(logging.Formatter, object):
         data = dict([(key, value % record.__dict__)
                      for key, value in self._fmt_dict.items()])
 
-        self._structuring(data, record.msg)
+        self._structuring(data, record.msg, record.args)
         return data
 
     def usesTime(self):
         return any([value.find('%(asctime)') >= 0
                     for value in self._fmt_dict.values()])
 
-    def _structuring(self, data, msg):
+    def _structuring(self, data, msg, args):
         """ Melds `msg` into `data`.
 
         :param data: dictionary to be sent to fluent server
@@ -73,7 +73,7 @@ class FluentRecordFormatter(logging.Formatter, object):
             try:
                 self._add_dic(data, json.loads(str(msg)))
             except ValueError:
-                self._add_dic(data, {'message': msg})
+                self._add_dic(data, {'message': msg % args})
         else:
             self._add_dic(data, {'message': msg})
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -88,7 +88,7 @@ class TestHandler(unittest.TestCase):
         log = logging.getLogger('fluent.test')
         handler.setFormatter(fluent.handler.FluentRecordFormatter())
         log.addHandler(handler)
-        log.info('hello world')
+        log.info('hello %s', 'world')
         handler.close()
 
         data = self.get_data()


### PR DESCRIPTION
When the messages are unstructured, the formatter ignore the arguments. Therefore, using `fluent.handler.FluentHandler` as a drop-in replacement for other handlers with standard Python logging does not always work well. This PR tries to solve it.