### PR TITLE
Parse JSON after format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ python:
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
     - "pip install --use-mirrors -e ."
-    - "pip install coverage coveralls"
+    - "pip install 'coverage>=3.7,<3.8' coveralls"
 script:
     - "python ./setup.py nosetests"
 after_success:

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ from fluent import handler
 
 custom_format = {
   'host': '%(hostname)s',
-  'where': '%(module)s.%(funcName)s'
+  'where': '%(module)s.%(funcName)s',
   'type': '%(levelname)s',
   'stack_trace': '%(exc_text)s'
 }

--- a/fluent/handler.py
+++ b/fluent/handler.py
@@ -93,16 +93,23 @@ class FluentHandler(logging.Handler):
                  host='localhost',
                  port=24224,
                  timeout=3.0,
-                 verbose=False):
+                 verbose=False,
+                 parse_json=False):
 
         self.tag = tag
         self.sender = sender.FluentSender(tag,
                                           host=host, port=port,
                                           timeout=timeout, verbose=verbose)
+        self.parse_json = parse_json
         logging.Handler.__init__(self)
 
     def emit(self, record):
         data = self.format(record)
+        if self.parse_json and isinstance(data, basestring):
+            try:
+                data = json.loads(data)
+            except ValueError:
+                pass
         self.sender.emit(None, data)
 
     def close(self):

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -121,3 +121,18 @@ class TestHandler(unittest.TestCase):
         data = self.get_data()
         # For some reason, non-string keys are ignored
         self.assertFalse(42 in data[0][2])
+
+    def test_parse_json(self):
+        handler = fluent.handler.FluentHandler('app.follow', port=self._port, parse_json=True)
+
+        logging.basicConfig(level=logging.INFO)
+        log = logging.getLogger('fluent.test')
+        handler.setFormatter(logging.Formatter())
+        log.addHandler(handler)
+        log.info('{"key": "hello world!", "param": "value"}')
+        handler.close()
+
+        data = self.get_data()
+        # For some reason, non-string keys are ignored
+        self.assertTrue('key' in data[0][2])
+        self.assertEqual('hello world!', data[0][2]['key'])

--- a/tox.ini
+++ b/tox.ini
@@ -5,5 +5,5 @@ skip_missing_interpreters = True
 
 [testenv]
 deps = nose
-    coverage
+    coverage>=3.7,<3.8
 commands = python setup.py nosetests


### PR DESCRIPTION
This change add feature to parse JSON after format.
It would be helpful to use FluentHandler with formatters
other than FluentRecordFormatter.

In my case, I want to use FluentHnadler with oslo_log.formatters.JSONFormatter.

https://github.com/openstack/oslo.log/blob/master/oslo_log/formatters.py#L64
