### PR TITLE
Fix formatter to handle %s style formatted messages

### DIFF
--- a/fluent/handler.py
+++ b/fluent/handler.py
@@ -51,21 +51,22 @@ class FluentRecordFormatter(logging.Formatter, object):
         data = dict([(key, value % record.__dict__)
                      for key, value in self._fmt_dict.items()])
 
-        self._structuring(data, record.msg)
+        self._structuring(data, record.msg, record.message)
         return data
 
     def usesTime(self):
         return any([value.find('%(asctime)') >= 0
                     for value in self._fmt_dict.values()])
 
-    def _structuring(self, data, msg):
-        """ Melds `msg` into `data`.
+    def _structuring(self, data, msg, message):
+        """ Melds `msg` into `data` using either original or formatted.
 
         :param data: dictionary to be sent to fluent server
         :param msg: :class:`LogRecord`'s message to add to `data`.
           `msg` can be a simple string for backward compatibility with
           :mod:`logging` framework, a JSON encoded string or a dictionary
           that will be merged into dictionary generated in :meth:`format.
+        :param message: :class:`LogRecord`'s formatted version of msg.
         """
         if isinstance(msg, dict):
             self._add_dic(data, msg)
@@ -73,9 +74,9 @@ class FluentRecordFormatter(logging.Formatter, object):
             try:
                 self._add_dic(data, json.loads(str(msg)))
             except ValueError:
-                self._add_dic(data, {'message': msg})
+                self._add_dic(data, {'message': message})
         else:
-            self._add_dic(data, {'message': msg})
+            self._add_dic(data, {'message': message})
 
     @staticmethod
     def _add_dic(data, dic):

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -95,6 +95,20 @@ class TestHandler(unittest.TestCase):
         self.assertTrue('message' in data[0][2])
         self.assertEqual('hello world', data[0][2]['message'])
 
+    def test_unstructured_formatted_message(self):
+        handler = fluent.handler.FluentHandler('app.follow', port=self._port)
+
+        logging.basicConfig(level=logging.INFO)
+        log = logging.getLogger('fluent.test')
+        handler.setFormatter(fluent.handler.FluentRecordFormatter())
+        log.addHandler(handler)
+        log.info('hello world, %s', 'you!')
+        handler.close()
+
+        data = self.get_data()
+        self.assertTrue('message' in data[0][2])
+        self.assertEqual('hello world, you!', data[0][2]['message'])
+
     def test_non_string_simple_message(self):
         handler = fluent.handler.FluentHandler('app.follow', port=self._port)
 


### PR DESCRIPTION
We want to use fluent-logger-python as a drop-in additional logging handler where we already have logging lines like this:

```
app.logger.warn("something is busted with %s", some_variable)
```

We have a custom format that includes `"%(message)s"` but what we see out from the fluent daemon are events with `"something is busted with %s"` for the `message` field which is not what we want.

This change passes both `msg` and `message` into `_structuring` so if the `msg` is neither a dictionary or a json-looking thing it will populate the `message` field with the formatted version the base formatter wrote.