### PR TITLE
Python 3.5 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
   - "2.6"
@@ -5,9 +6,10 @@ python:
   - "3.2"
   - "3.3"
   - "3.4"
+  - "3.5"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-    - "pip install --use-mirrors -e ."
+    - "pip install -e ."
     - "pip install 'coverage>=3.7,<3.8' coveralls"
 script:
     - "python ./setup.py nosetests"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.7.2
-envlist = py26, py27, py32, py33, py34
+envlist = py26, py27, py32, py33, py34, py35
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Also make Travis tests go a bit faster using `sudo: false` to use containers as per https://docs.travis-ci.com/user/workers/container-based-infrastructure/

Test Plan: local `tox` + Travis build attached to PR.