### PR TITLE
Show traceback on timeout (Python>=3.3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ install:
     - "pip install -e ."
     - "pip install 'coverage>=3.7,<3.8' coveralls"
 script:
-    - "python ./setup.py nosetests"
+    - "PYTHONFAULTHANDLER=x timeout -sABRT 30s nosetests -vsd"
 after_success:
     - coveralls

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -16,13 +16,14 @@ class MockRecvServer(threading.Thread):
     """
     Single threaded server accepts one connection and recv until EOF.
     """
-    def __init__(self, host='localhost', port=24224):
+    def __init__(self, host='localhost', port=0):
         if host.startswith('unix://'):
             self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
             self._sock.bind(host[len('unix://'):])
         else:
             self._sock = socket.socket()
             self._sock.bind((host, port))
+            self.port = self._sock.getsockname()[1]
         self._sock.listen(1)
         self._buf = BytesIO()
 

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -23,6 +23,7 @@ class MockRecvServer(threading.Thread):
         else:
             self._sock = socket.socket()
             self._sock.bind((host, port))
+        self._sock.listen(1)
         self._buf = BytesIO()
 
         threading.Thread.__init__(self)
@@ -30,7 +31,6 @@ class MockRecvServer(threading.Thread):
 
     def run(self):
         sock = self._sock
-        sock.listen(1)
         con, _ = sock.accept()
         while True:
             data = con.recv(4096)

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -11,13 +11,8 @@ from tests import mockserver
 class TestHandler(unittest.TestCase):
     def setUp(self):
         super(TestHandler, self).setUp()
-        for port in range(10000, 20000):
-            try:
-                self._server = mockserver.MockRecvServer('localhost', port)
-                self._port = port
-                break
-            except IOError:
-                pass
+        self._server = mockserver.MockRecvServer('localhost')
+        self._port = self._server.port
 
     def get_data(self):
         return self._server.get_recieved()

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -41,13 +41,9 @@ class TestSetup(unittest.TestCase):
 class TestSender(unittest.TestCase):
     def setUp(self):
         super(TestSender, self).setUp()
-        for port in range(10000, 20000):
-            try:
-                self._server = mockserver.MockRecvServer('localhost', port)
-                break
-            except IOError as exc:
-                print(exc)
-        self._sender = fluent.sender.FluentSender(tag='test', port=port)
+        self._server = mockserver.MockRecvServer('localhost')
+        self._sender = fluent.sender.FluentSender(tag='test',
+                                                  port=self._server.port)
 
     def get_data(self):
         return self._server.get_recieved()


### PR DESCRIPTION
Python >=3.3 has [faulthandler](https://docs.python.org/3.5/using/cmdline.html#envvar-PYTHONFAULTHANDLER).
It can be used to display traceback on signal.

This may be useful to investigate random timeout in Travis environment.