### PR TITLE
README - mention msgpack-python is dependency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,7 @@ Requirements
 ------------
 
 -  Python 2.6 or greater including 3.x
+- ``msgpack-python``
 
 Installation
 ------------


### PR DESCRIPTION
I went to check the package for its requirements and saw this section, when I read it I thought it had no python depedencies. However looking at `setup.py` it's clear `msgpack-python` is required.