### PR TITLE
Fix sample configuration logging.yaml work in python3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -244,15 +244,15 @@ A sample configuration ``logging.yaml`` would be:
                 tag: test.logging
                 formatter: fluent_fmt
                 level: DEBUG
-            null:
+            none:
                 class: logging.NullHandler
 
         loggers:
             amqp:
-                handlers: [null]
+                handlers: [none]
                 propagate: False
             conf:
-                handlers: [null]
+                handlers: [none]
                 propagate: False
             '': # root logger
                 handlers: [console, fluent]


### PR DESCRIPTION
In Python3 with PyYAML, logging.config.dictConfig sample not working, got errors as follows:

```
Traceback (most recent call last):
  File "test.py", line 7, in <module>
    logging.config.dictConfig(conf['logging'])
  File "/Users/takashibagura/.pyenv/versions/3.5.0/lib/python3.5/logging/config.py", line 795, in dictConfig
    dictConfigClass(config).configure()
  File "/Users/takashibagura/.pyenv/versions/3.5.0/lib/python3.5/logging/config.py", line 556, in configure
    for name in sorted(handlers):
TypeError: unorderable types: str() < NoneType()
```

I was changed the key of handlers is not to None.
