### PR TITLE
Release as a universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,3 +6,5 @@ cover-erase = 1
 cover-branches = 1
 cover-inclusive = 1
 cover-min-percentage = 70
+[bdist_wheel]
+universal = 1


### PR DESCRIPTION
By releasing as a [Python wheel](http://pythonwheels.com/) as well as a source distribution, you can speed up end user’s installs. After merging this command, to release you just need to run `python setup.py clean sdist bdist_wheel upload`.