### PR TITLE
This patch supports sending logs over UDP

### DIFF
--- a/fluent/handler.py
+++ b/fluent/handler.py
@@ -132,7 +132,7 @@ class FluentHandler(logging.Handler):
     def close(self):
         self.acquire()
         try:
-            self.sender._close()
+            self.sender.close()
             logging.Handler.close(self)
         finally:
             self.release()

--- a/fluent/transport.py
+++ b/fluent/transport.py
@@ -1,0 +1,70 @@
+# encoding=utf-8
+
+import socket
+
+
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
+
+
+class Transport(object):
+    def __init__(self, host, port, timeout):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+
+        self._conn = None
+
+    def close(self):
+        if self._conn:
+            self._conn.close()
+            self._conn = None
+
+    def connect(self):
+        if self._conn:
+            return
+
+        family, socket_type, addr = get_connection_params(self.host, self.port)
+        self._conn = socket.socket(family, socket_type)
+        self._conn.connect(addr)
+        self._conn.settimeout(self.timeout)
+
+    def send(self, data):
+        self.connect()
+        self._conn.sendall(data)
+
+
+def get_connection_params(host, port=0):
+    parsed = urlparse(host)
+
+    port = parsed.port or port or 0
+
+    scheme = parsed.scheme.lower()
+    if scheme == 'unix':
+        family = socket.AF_UNIX
+        socket_type = socket.SOCK_STREAM
+        addr = parsed.hostname
+
+    elif scheme == 'udp':
+        family = socket.AF_INET
+        socket_type = socket.SOCK_DGRAM
+        addr = (parsed.hostname, port)
+
+    elif scheme in ('tcp', ''):
+        family = socket.AF_INET
+        socket_type = socket.SOCK_STREAM
+        addr = (parsed.hostname or parsed.path, port)
+
+    else:
+        raise TransportError(
+            "Unknown connection protocol: host={}, port={}".format(
+                host, port,
+            )
+        )
+
+    return family, socket_type, addr
+
+
+TransportError = socket.error

--- a/fluent/transport.py
+++ b/fluent/transport.py
@@ -35,8 +35,8 @@ class Transport(object):
         self._conn.sendall(data)
 
 
-def get_connection_params(host, port=0):
-    parsed = urlparse(host)
+def get_connection_params(url, port=0):
+    parsed = urlparse(url)
 
     port = parsed.port or port or 0
 
@@ -58,8 +58,8 @@ def get_connection_params(host, port=0):
 
     else:
         raise TransportError(
-            "Unknown connection protocol: host={}, port={}".format(
-                host, port,
+            "Unknown connection protocol: url={}, port={}".format(
+                url, port,
             )
         )
 

--- a/fluent/transport.py
+++ b/fluent/transport.py
@@ -2,7 +2,6 @@
 
 import socket
 
-
 try:
     from urllib.parse import urlparse
 except ImportError:

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -1,54 +1,108 @@
 # -*- coding: utf-8 -*-
 
+import socket
+
 try:
     from cStringIO import StringIO as BytesIO
 except ImportError:
     from io import BytesIO
 
-import socket
-import threading
-import time
-
 from msgpack import Unpacker
 
+from fluent.transport import get_connection_params
 
-class MockRecvServer(threading.Thread):
-    """
-    Single threaded server accepts one connection and recv until EOF.
-    """
-    def __init__(self, host='localhost', port=0):
-        if host.startswith('unix://'):
-            self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-            self._sock.bind(host[len('unix://'):])
+
+def create_server(host, port=0):
+    family, socket_type, addr = get_connection_params(host, port)
+
+    if socket_type == UDPServer.SOCKET_TYPE:
+        conn_type = UDPServer
+    else:
+        if family == socket.AF_UNIX:
+            conn_type = UnixSocketServer
         else:
-            self._sock = socket.socket()
-            self._sock.bind((host, port))
-            self.port = self._sock.getsockname()[1]
-        self._sock.listen(1)
-        self._buf = BytesIO()
+            conn_type = TCPServer
 
-        threading.Thread.__init__(self)
-        self.start()
+    conn = conn_type(family, addr)
+    conn.listen()
+    return conn
 
-    def run(self):
-        sock = self._sock
-        con, _ = sock.accept()
+
+class Server(object):
+    SOCKET_TYPE = ""
+
+    def __init__(self, family, addr):
+        self._family = family
+        self._addr = addr
+
+        self._sock = socket.socket(self._family, self.SOCKET_TYPE)
+        self._sock.bind(self._addr)
+        self._sock.settimeout(0.5)
+
+    def listen(self):
+        # Okay move along, move along people, there's nothing to see here!
+        pass
+
+    def recv(self, qty_messages=1):
+        data = BytesIO()
         while True:
-            data = con.recv(4096)
-            if not data:
+            chunk = self.recv_raw()
+            data.seek(0, 2)
+            data.write(chunk)
+
+            data.seek(0)
+            messages = list(Unpacker(data, encoding='utf-8'))
+            if len(messages) >= qty_messages:
                 break
-            self._buf.write(data)
-        con.close()
-        sock.close()
-        self._sock = None
 
-    def wait(self):
-        while self._sock:
-            time.sleep(0.1)
+        return list(messages)
 
-    def get_recieved(self):
-        self.wait()
-        self._buf.seek(0)
-        # TODO: have to process string encoding properly. currently we assume
-        # that all encoding is utf-8.
-        return list(Unpacker(self._buf, encoding='utf-8'))
+    def recv_raw(self, limit=1024):
+        raise NotImplementedError
+
+    def close(self):
+        self._sock.close()
+
+    def addr(self):
+        raise NotImplementedError
+
+
+class TCPServer(Server):
+    SOCKET_TYPE = socket.SOCK_STREAM
+
+    def __init__(self, *args, **kwargs):
+        super(TCPServer, self).__init__(*args, **kwargs)
+
+        self.accepted_connection = None
+
+    def listen(self):
+        self._sock.listen(1)
+
+    def recv_raw(self, limit=1024):
+        if not self.accepted_connection:
+            self.accepted_connection, _ = self._sock.accept()
+
+        return self.accepted_connection.recv(limit)
+
+    def close(self):
+        super(TCPServer, self).close()
+        if self.accepted_connection:
+            self.accepted_connection.close()
+
+    def addr(self):
+        return "tcp://{}:{}".format(*self._sock.getsockname())
+
+
+class UnixSocketServer(TCPServer):
+    def addr(self):
+        return "unix://{}".format(self._sock.getsockname())
+
+
+class UDPServer(Server):
+    SOCKET_TYPE = socket.SOCK_DGRAM
+
+    def recv_raw(self, limit=1024):
+        return self._sock.recv(limit)
+
+    def addr(self):
+        return "udp://{}:{}".format(*self._sock.getsockname())


### PR DESCRIPTION
To send logs over udp you need to specify host parameter as udp://ip[:port]. If you want to use TCP you may specify no prefixes at all or define host as tcp://ip[:port].
Also I have made some changes in tests, namely, I have replaced thread-based realization of fluent's mock with thin wrapper of socket object. It makes possible to use old tests to test both tpc and udp implementations. Also it makes tests more straight and clear, because you can check messages recieved by mock in real-time (now you cannot check messages before connection to mock is closed).