### PR TITLE
Gracefully close the socket.

### DIFF
--- a/fluent/sender.py
+++ b/fluent/sender.py
@@ -197,6 +197,7 @@ class FluentSender(object):
 
     def _close(self):
         if self.socket:
+            self.socket.shutdown(socket.SHUT_RDWR)
             self.socket.close()
         self.socket = None
 


### PR DESCRIPTION
Calling .shutdown on the socket before .close(), notifies the other end that we are closing down. It should also ease subsequent further startups, without dangling connections.