### PR TITLE
Fix the asyncsender and make the asyncsender queue a bounded-size circular buffer by default.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -353,8 +353,8 @@ the thread, unless forcibly killed.
 In some applications it can be especially important to guarantee that the logging process won't block under *any*
 circumstance, even when it's logging faster than the sending thread could handle (_backpressure_). In this case it's
 possible to enable the `circular queue` mode, by passing `True` in the `queue_circular` parameter of
-``asyncsender.FluentSender``. By doing so the thread doing the logging won't block even when the queue is full, the
-new event will be added to the queue by discarding the oldest one.
+``asyncsender.FluentSender`` or ``asynchandler.FluentHandler``. By doing so the thread doing the logging won't block
+even when the queue is full, the new event will be added to the queue by discarding the oldest one.
 
 **WARNING**: setting `queue_circular` to `True` will cause loss of events if the queue fills up completely! Make sure
 that this doesn't happen, or it's acceptable for your application.

--- a/README.rst
+++ b/README.rst
@@ -348,6 +348,18 @@ or for the python logging interface:
 sure the communication thread terminates and it's joined correctly. Otherwise the program won't exit, waiting for
 the thread, unless forcibly killed.
 
+#### Circular queue mode
+
+In some applications it can be especially important to guarantee that the logging process won't block under *any*
+circumstance, even when it's logging faster than the sending thread could handle (_backpressure_). In this case it's
+possible to enable the `circular queue` mode, by passing `True` in the `queue_circular` parameter of
+``asyncsender.FluentSender``. By doing so the thread doing the logging won't block even when the queue is full, the
+new event will be added to the queue by discarding the oldest one.
+
+**WARNING**: setting `queue_circular` to `True` will cause loss of events if the queue fills up completely! Make sure
+that this doesn't happen, or it's acceptable for your application.
+
+
 Testing
 -------
 

--- a/fluent/asyncsender.py
+++ b/fluent/asyncsender.py
@@ -138,12 +138,6 @@ class CommunicatorThread(threading.Thread):
     def queue_circular(self):
         return self._queue_circular
 
-    def __enter__(self):
-        return self
-
-    def __exit__(self, typ, value, traceback):
-        self.close()
-
 
 class FluentSender(sender.FluentSender):
     def __init__(self,

--- a/fluent/asyncsender.py
+++ b/fluent/asyncsender.py
@@ -67,7 +67,7 @@ class CommunicatorThread(threading.Thread):
             # discard oldest
             try:
                 self._queue.get(block=False)
-            except Empty:
+            except Empty:   # pragma: no cover
                 pass
         try:
             self._queue.put(bytes_, block=(not self._queue_circular))
@@ -179,10 +179,10 @@ class FluentSender(sender.FluentSender):
         self._communicator._close()
 
     def _send_internal(self, bytes_):
-        return
+        assert False    # pragma: no cover
 
     def _send_data(self, bytes_):
-        return
+        assert False    # pragma: no cover
 
     # override reconnect, so we don't open a socket here (since it
     # will be opened by the CommunicatorThread)

--- a/fluent/asyncsender.py
+++ b/fluent/asyncsender.py
@@ -14,6 +14,8 @@ from fluent.sender import EventTime
 _global_sender = None
 
 DEFAULT_QUEUE_TIMEOUT = 0.05
+DEFAULT_QUEUE_MAXSIZE = 100
+DEFAULT_QUEUE_CIRCULAR = False
 
 
 def _set_global_sender(sender):
@@ -46,19 +48,29 @@ class CommunicatorThread(threading.Thread):
                  buffer_overflow_handler=None,
                  nanosecond_precision=False,
                  msgpack_kwargs=None,
-                 queue_timeout=DEFAULT_QUEUE_TIMEOUT, *args, **kwargs):
+                 queue_timeout=DEFAULT_QUEUE_TIMEOUT,
+                 queue_maxsize=DEFAULT_QUEUE_MAXSIZE,
+                 queue_circular=DEFAULT_QUEUE_CIRCULAR, *args, **kwargs):
         super(CommunicatorThread, self).__init__(**kwargs)
-        self._queue = Queue()
+        self._queue = Queue(maxsize=queue_maxsize)
         self._do_run = True
         self._queue_timeout = queue_timeout
+        self._queue_maxsize = queue_maxsize
+        self._queue_circular = queue_circular
         self._conn_close_lock = threading.Lock()
         self._sender = sender.FluentSender(tag=tag, host=host, port=port, bufmax=bufmax, timeout=timeout,
                                            verbose=verbose, buffer_overflow_handler=buffer_overflow_handler,
                                            nanosecond_precision=nanosecond_precision, msgpack_kwargs=msgpack_kwargs)
 
     def send(self, bytes_):
+        if self._queue_circular and self._queue.full():
+            # discard oldest
+            try:
+                self._queue.get(block=False)
+            except Empty:
+                pass
         try:
-            self._queue.put(bytes_)
+            self._queue.put(bytes_, block=(not self._queue_circular))
         except Full:
             return False
         return True
@@ -114,6 +126,18 @@ class CommunicatorThread(threading.Thread):
     def queue_timeout(self, value):
         self._queue_timeout = value
 
+    @property
+    def queue_maxsize(self):
+        return self._queue_maxsize
+
+    @property
+    def queue_blocking(self):
+        return not self._queue_circular
+
+    @property
+    def queue_circular(self):
+        return self._queue_circular
+
     def __enter__(self):
         return self
 
@@ -133,6 +157,8 @@ class FluentSender(sender.FluentSender):
                  nanosecond_precision=False,
                  msgpack_kwargs=None,
                  queue_timeout=DEFAULT_QUEUE_TIMEOUT,
+                 queue_maxsize=DEFAULT_QUEUE_MAXSIZE,
+                 queue_circular=DEFAULT_QUEUE_CIRCULAR,
                  **kwargs): # This kwargs argument is not used in __init__. This will be removed in the next major version.
         super(FluentSender, self).__init__(tag=tag, host=host, port=port, bufmax=bufmax, timeout=timeout,
                                            verbose=verbose, buffer_overflow_handler=buffer_overflow_handler,
@@ -141,7 +167,8 @@ class FluentSender(sender.FluentSender):
         self._communicator = CommunicatorThread(tag=tag, host=host, port=port, bufmax=bufmax, timeout=timeout,
                                                 verbose=verbose, buffer_overflow_handler=buffer_overflow_handler,
                                                 nanosecond_precision=nanosecond_precision, msgpack_kwargs=msgpack_kwargs,
-                                                queue_timeout=queue_timeout)
+                                                queue_timeout=queue_timeout, queue_maxsize=queue_maxsize,
+                                                queue_circular=queue_circular)
         self._communicator.start()
 
     def _send(self, bytes_):
@@ -185,6 +212,18 @@ class FluentSender(sender.FluentSender):
     @queue_timeout.setter
     def queue_timeout(self, value):
         self._communicator.queue_timeout = value
+
+    @property
+    def queue_maxsize(self):
+        return self._communicator.queue_maxsize
+
+    @property
+    def queue_blocking(self):
+        return self._communicator.queue_blocking
+
+    @property
+    def queue_circular(self):
+        return self._communicator.queue_circular
 
     def __enter__(self):
         return self

--- a/fluent/handler.py
+++ b/fluent/handler.py
@@ -152,7 +152,8 @@ class FluentHandler(logging.Handler):
                  verbose=False,
                  buffer_overflow_handler=None,
                  msgpack_kwargs=None,
-                 nanosecond_precision=False):
+                 nanosecond_precision=False,
+                 **kwargs):
 
         self.tag = tag
         self.sender = self.getSenderInstance(tag,
@@ -160,7 +161,8 @@ class FluentHandler(logging.Handler):
                                              timeout=timeout, verbose=verbose,
                                              buffer_overflow_handler=buffer_overflow_handler,
                                              msgpack_kwargs=msgpack_kwargs,
-                                             nanosecond_precision=nanosecond_precision)
+                                             nanosecond_precision=nanosecond_precision,
+                                             **kwargs)
         logging.Handler.__init__(self)
 
     def getSenderClass(self):
@@ -168,14 +170,14 @@ class FluentHandler(logging.Handler):
 
     def getSenderInstance(self, tag, host, port, timeout, verbose,
                           buffer_overflow_handler, msgpack_kwargs,
-                          nanosecond_precision):
+                          nanosecond_precision, **kwargs):
         sender_class = self.getSenderClass()
         return sender_class(tag,
                             host=host, port=port,
                             timeout=timeout, verbose=verbose,
                             buffer_overflow_handler=buffer_overflow_handler,
                             msgpack_kwargs=msgpack_kwargs,
-                            nanosecond_precision=nanosecond_precision)
+                            nanosecond_precision=nanosecond_precision, **kwargs)
 
     def emit(self, record):
         data = self.format(record)


### PR DESCRIPTION
The asyncsender was potentially blocking before, and it should never be.

Add the `queue_circular` and `queue_maxsize` options to `asyncsender.FluentSender`.
By default the circular buffer mode is on, so to avoid having potentially inifinite memory allocations (and OOM kills...).
