### PR TITLE
README: fix the reStructuredText formatting.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -348,10 +348,11 @@ or for the python logging interface:
 sure the communication thread terminates and it's joined correctly. Otherwise the program won't exit, waiting for
 the thread, unless forcibly killed.
 
-#### Circular queue mode
+Circular queue mode
++++++++++++++++++++
 
 In some applications it can be especially important to guarantee that the logging process won't block under *any*
-circumstance, even when it's logging faster than the sending thread could handle (_backpressure_). In this case it's
+circumstance, even when it's logging faster than the sending thread could handle (*backpressure*). In this case it's
 possible to enable the `circular queue` mode, by passing `True` in the `queue_circular` parameter of
 ``asyncsender.FluentSender`` or ``asynchandler.FluentHandler``. By doing so the thread doing the logging won't block
 even when the queue is full, the new event will be added to the queue by discarding the oldest one.


### PR DESCRIPTION
This commit fixes reStructuredText formatting errors in README.rst:

* `# hash` is not recognized as a section header.
* `_underscore_` does not show a text with italics font style.

For comparison, here is how it looks like now:

![2017-12-08-151322_907x173_scrot](https://user-images.githubusercontent.com/8974561/33753386-62bb9426-dc2a-11e7-94fb-481ffb25bde7.png)

and after this commit:

![2017-12-08-151259_912x173_scrot](https://user-images.githubusercontent.com/8974561/33753396-6b906a4a-dc2a-11e7-97fc-b25f754448a2.png)
