### PR TITLE
can not work with msgpack-python==0.5 on AmazonLinux

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
   long_description=open(README).read(),
   package_dir={'fluent': 'fluent'},
   packages=['fluent'],
-  install_requires=['msgpack-python'],
+  install_requires=['msgpack-python<=0.4.8'],
   author='Kazuki Ohta',
   author_email='kazuki.ohta@gmail.com',
   url='https://github.com/fluent/fluent-logger-python',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
   long_description=open(README).read(),
   package_dir={'fluent': 'fluent'},
   packages=['fluent'],
-  install_requires=['msgpack-python<=0.4.8'],
+  install_requires=['msgpack'],
   author='Kazuki Ohta',
   author_email='kazuki.ohta@gmail.com',
   url='https://github.com/fluent/fluent-logger-python',


### PR DESCRIPTION
```msgpack-python==0.5``` contains some bug.
We can not install it correctly. (only `msgpack_python-0.5.0.egg-info/`)

I think that it is better to specify a specific version.

log sample
```shell
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/site-packages/fluent/sender.py", line 12, in <module>
    import msgpack
ImportError: No module named msgpack
```
  