### PR TITLE
Change to msgpack from msgpack-python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
   long_description=open(README).read(),
   package_dir={'fluent': 'fluent'},
   packages=['fluent'],
-  install_requires=['msgpack-python'],
+  install_requires=['msgpack-python<=0.4.8'],
   author='Kazuki Ohta',
   author_email='kazuki.ohta@gmail.com',
   url='https://github.com/fluent/fluent-logger-python',

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
   long_description=open(README).read(),
   package_dir={'fluent': 'fluent'},
   packages=['fluent'],
-  install_requires=['msgpack-python<=0.4.8'],
+  install_requires=['msgpack'],
   author='Kazuki Ohta',
   author_email='kazuki.ohta@gmail.com',
   url='https://github.com/fluent/fluent-logger-python',


### PR DESCRIPTION
After 0.5.0, `pip install msgpack` is recomended. (Not `msgpack-python`)

https://github.com/msgpack/msgpack-python/tree/0.5.0
