### PR TITLE
Perform a non-blocking read-side check before and after send

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ desc = 'A Python logging handler for Fluentd event collector'
 
 setup(
   name='fluent-logger',
-  version='0.9.0',
+  version='0.9.9',
   description=desc,
   long_description=open(README).read(),
   package_dir={'fluent': 'fluent'},

--- a/tests/test_asynchandler.py
+++ b/tests/test_asynchandler.py
@@ -2,7 +2,6 @@
 
 import logging
 import sys
-import time
 import unittest
 
 import fluent.asynchandler


### PR DESCRIPTION
This allows early connection problem detection without sending data
into a dead socket.