### PR TITLE
Include exception stack trace in 'message'

### DIFF
--- a/fluent/handler.py
+++ b/fluent/handler.py
@@ -131,12 +131,12 @@ class FluentRecordFormatter(logging.Formatter, object):
             if isinstance(json_msg, dict):
                 return json_msg
             else:
-                return {'message': str(json_msg)}
+                return self._format_msg_default(record, msg)
         except ValueError:
             return self._format_msg_default(record, msg)
 
     def _format_msg_default(self, record, msg):
-        return {'message': record.getMessage()}
+        return {'message': super(FluentRecordFormatter, self).format(record)}
 
     def _format_by_exclusion(self, record):
         data = {}

--- a/tests/test_asynchandler.py
+++ b/tests/test_asynchandler.py
@@ -239,6 +239,26 @@ class TestHandler(unittest.TestCase):
         # For some reason, non-string keys are ignored
         self.assertFalse(42 in data[0][2])
 
+    def test_exception_message(self):
+        handler = self.get_handler_class()('app.follow', port=self._port)
+
+        with handler:
+            logging.basicConfig(level=logging.INFO)
+            log = logging.getLogger('fluent.test')
+            handler.setFormatter(fluent.handler.FluentRecordFormatter())
+            log.addHandler(handler)
+            try:
+                raise Exception('sample exception')
+            except Exception:
+                log.exception('it failed')
+
+        data = self.get_data()
+        message = data[0][2]['message']
+        # Includes the logged message, as well as the stack trace.
+        self.assertTrue('it failed' in message)
+        self.assertTrue('tests/test_asynchandler.py", line' in message)
+        self.assertTrue('Exception: sample exception' in message)
+
 
 class TestHandlerWithCircularQueue(unittest.TestCase):
     Q_SIZE = 3


### PR DESCRIPTION
**Problem:**  Since switching from the builtin log handlers to fluent-logger-python, when an exception occurs in my web application, I only receive the single line from `LogRecord.msg` (e.g. `{"message": "Internal Server Error: /"`).  The traceback and root exception are not present, making debugging nearly impossible.

**Solution:** In this PR, when we do not have a dict or JSON message, instead of using `LogRecord.msg` we call [`logging.Formatter.format()`](https://github.com/python/cpython/blob/v3.6.0/Lib/logging/__init__.py#L557).  For existing debug/info/warn/error string messages, this will result in no change, but when there is an exception, it will include the `exc_text` in the message, as is common with the builtin logging Formatters. For example: `{'message': 'it failed\nTraceback (most recent call last):\n  File "[..]/fluent-logger-python/tests/test_handler.py", line 363, in test_exception_message\n    raise Exception(\'sample exception\')\nException: sample exception'}`

**Alternative Solutions:**
- As mentioned in the README, the formatter could be configured with `'stack_trace': '%(exc_text)s'`. The downside to this approach is that 1) the majority of log statements which lack an exception will have an unnecessary `"stack_trace": "None"`, 2) it is surprising behavior to new library users that the message does not include the normal trace info.
- There have been prior PRs (https://github.com/fluent/fluent-logger-python/pull/19 and https://github.com/fluent/fluent-logger-python/pull/38) which have manually used the traceback module to simulate what LogRecord.exc_text provides.