### PR TITLE
added lazy sender initializer

### DIFF
--- a/fluent/handler.py
+++ b/fluent/handler.py
@@ -192,17 +192,35 @@ class FluentHandler(logging.Handler):
                  **kwargs):
 
         self.tag = tag
-        self.sender = self.getSenderInstance(tag,
-                                             host=host, port=port,
-                                             timeout=timeout, verbose=verbose,
-                                             buffer_overflow_handler=buffer_overflow_handler,
-                                             msgpack_kwargs=msgpack_kwargs,
-                                             nanosecond_precision=nanosecond_precision,
-                                             **kwargs)
+        self._host = host
+        self._port = port
+        self._timeout = timeout
+        self._verbose = verbose
+        self._buffer_overflow_handler = buffer_overflow_handler
+        self._msgpack_kwargs = msgpack_kwargs
+        self._nanosecond_precision = nanosecond_precision
+        self._kwargs = kwargs
+        self._sender = None
         logging.Handler.__init__(self)
 
     def getSenderClass(self):
         return sender.FluentSender
+
+    @property
+    def sender(self):
+        if self._sender is None:
+            self._sender = self.getSenderInstance(
+                tag=self.tag,
+                host=self._host,
+                port=self._port,
+                timeout=self._timeout,
+                verbose=self._verbose,
+                buffer_overflow_handler=self._buffer_overflow_handler,
+                msgpack_kwargs=self._msgpack_kwargs,
+                nanosecond_precision=self._nanosecond_precision,
+                **self._kwargs
+            )
+        return self._sender
 
     def getSenderInstance(self, tag, host, port, timeout, verbose,
                           buffer_overflow_handler, msgpack_kwargs,


### PR DESCRIPTION
These changes provide the lazy initializer for the sender instance. It can help with issue with forked scripts like uwsgi:
http://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html

> uWSGI tries to (ab)use the Copy On Write semantics of the fork() call whenever possible. 
> By default it will fork after having loaded your applications to share as much of their memory as possible.
> 

So we should create `Queue` after `fork`.

PS Also, I faced this issue in celery and this fix helps me.