### PR TITLE
added explicit type cast to string to `FluentRecordFormatter` for `exclude_attrs` case.

### DIFF
--- a/fluent/handler.py
+++ b/fluent/handler.py
@@ -142,7 +142,7 @@ class FluentRecordFormatter(logging.Formatter, object):
         data = {}
         for key, value in record.__dict__.items():
             if key not in self._exc_attrs:
-                data[key] = value
+                data[key] = str(value)
         return data
 
     def _format_by_dict(self, record):


### PR DESCRIPTION
Case:
1. Using `FluentRecordFormatter` with `exclude_attrs=[]`.
2. Create log record with uuid: `logger.info('Some info', uuid=uuid4())`
3. catch `TypeError: can't serialize UUID('fea00603-ef79-4f11-aff5-b05ee2f68111')`

`msgpack` has limitations for input data, so it has to be cast to simple data types. 