### PR TITLE
Add compatibility for Ipv6 address

### DIFF
--- a/fluent/sender.py
+++ b/fluent/sender.py
@@ -121,6 +121,17 @@ class FluentSender(object):
 
             self._close()
             self.pendings = None
+            
+    def _host_is_ipv6(self) :
+      try :
+        socket.inet_pton(socket.AF_INET6, self.host)
+        return True
+      except :
+        try :
+          socket.inet_aton(self.host)
+          return False
+        except Exception as e:
+          raise e
 
     def _make_packet(self, label, timestamp, data):
         if label:
@@ -203,7 +214,10 @@ class FluentSender(object):
                     sock.settimeout(self.timeout)
                     sock.connect(self.host[len('unix://'):])
                 else:
-                    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+                    if self._host_is_ipv6() :
+                      sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+                    else :
+                      sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
                     sock.settimeout(self.timeout)
                     # This might be controversial and may need to be removed
                     sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)


### PR DESCRIPTION
Fixes: #137 

Currently the library does not support Ipv6 as host adress. To make it compatible with Ipv6 I added a function that check if host is Ipv6 and if the address is Ipv6 we can connect to Ipv6 socket otherwise we can fallback to Ipv4 socket.