### PR TITLE
Bump msgpack version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
   long_description=open(README).read(),
   package_dir={'fluent': 'fluent'},
   packages=['fluent'],
-  install_requires=['msgpack<1.0.0'],
+  install_requires=['msgpack>=1.0.0'],
   author='Kazuki Ohta',
   author_email='kazuki.ohta@gmail.com',
   url='https://github.com/fluent/fluent-logger-python',

--- a/tests/mockserver.py
+++ b/tests/mockserver.py
@@ -68,7 +68,7 @@ class MockRecvServer(threading.Thread):
         self._buf.seek(0)
         # TODO: have to process string encoding properly. currently we assume
         # that all encoding is utf-8.
-        return list(Unpacker(self._buf, encoding='utf-8'))
+        return list(Unpacker(self._buf))
 
     def close(self):
 


### PR DESCRIPTION
Since the `encoding` option is always UTF-8 with msgpack>=1, I've remove the same.

Otherwise it fails with:

```
$ python3 setup.py nosetests
running nosetests
running egg_info
creating fluent_logger.egg-info
writing fluent_logger.egg-info/PKG-INFO
writing dependency_links to fluent_logger.egg-info/dependency_links.txt
writing requirements to fluent_logger.egg-info/requires.txt
writing top-level names to fluent_logger.egg-info/top_level.txt
writing manifest file 'fluent_logger.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching 'test/*py'
writing manifest file 'fluent_logger.egg-info/SOURCES.txt'
E.EEEEEEEEEEEE...SE.EE..E.EEEEE...S...E.EEEEEEEEEEEEEEEE...EEE..EE.EE....
======================================================================
ERROR: test_custom_field_fill_missing_fmt_key_is_true (tests.test_asynchandler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 164, in test_custom_field_fill_missing_fmt_key_is_true
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 37, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: {'sample': 'value'}
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_custom_fmt (tests.test_asynchandler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 78, in test_custom_fmt
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 37, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: {'sample': 'value'}
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_custom_fmt_with_format_style (tests.test_asynchandler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 101, in test_custom_fmt_with_format_style
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 37, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: {'sample': 'value'}
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_custom_fmt_with_template_style (tests.test_asynchandler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 124, in test_custom_fmt_with_template_style
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 37, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: {'sample': 'value'}
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_exception_message (tests.test_asynchandler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 266, in test_exception_message
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 37, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: ERROR: it failed
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 262, in test_exception_message
    raise Exception('sample exception')
Exception: sample exception
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_json_encoded_message (tests.test_asynchandler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 181, in test_json_encoded_message
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 37, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: {"key": "hello world!", "param": "value"}
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_non_string_dict_message (tests.test_asynchandler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 249, in test_non_string_dict_message
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 37, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: {42: 'root'}
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_non_string_simple_message (tests.test_asynchandler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 236, in test_non_string_simple_message
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 37, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: 42
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_number_string_simple_message (tests.test_asynchandler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 223, in test_number_string_simple_message
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 37, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: 1
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_simple (tests.test_asynchandler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 52, in test_simple
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 37, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: {'from': 'userA', 'to': 'userB'}
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_unstructured_formatted_message (tests.test_asynchandler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 209, in test_unstructured_formatted_message
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 37, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: hello world, you!
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_unstructured_message (tests.test_asynchandler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 195, in test_unstructured_message
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 37, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: hello world
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_simple (tests.test_asynchandler.TestHandlerWithCircularQueue)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 310, in test_simple
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asynchandler.py", line 290, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: {'cnt': 1, 'from': 'userA', 'to': 'userB'}
fluent.test: INFO: {'cnt': 2, 'from': 'userA', 'to': 'userB'}
fluent.test: INFO: {'cnt': 3, 'from': 'userA', 'to': 'userB'}
fluent.test: INFO: {'cnt': 4, 'from': 'userA', 'to': 'userB'}
fluent.test: INFO: {'cnt': 5, 'from': 'userA', 'to': 'userB'}
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_decorator_simple (tests.test_asyncsender.TestSender)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asyncsender.py", line 80, in test_decorator_simple
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asyncsender.py", line 61, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'

======================================================================
ERROR: test_nanosecond (tests.test_asyncsender.TestSender)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asyncsender.py", line 94, in test_nanosecond
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asyncsender.py", line 61, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'

======================================================================
ERROR: test_nanosecond_coerce_float (tests.test_asyncsender.TestSender)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asyncsender.py", line 109, in test_nanosecond_coerce_float
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asyncsender.py", line 61, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'

======================================================================
ERROR: test_simple (tests.test_asyncsender.TestSender)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asyncsender.py", line 67, in test_simple
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asyncsender.py", line 61, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'

======================================================================
ERROR: test_simple (tests.test_asyncsender.TestSenderUnlimitedSize)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asyncsender.py", line 363, in test_simple
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asyncsender.py", line 350, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'

======================================================================
ERROR: test_simple (tests.test_asyncsender.TestSenderWithTimeout)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asyncsender.py", line 200, in test_simple
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asyncsender.py", line 194, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'

======================================================================
ERROR: test_simple_with_timeout_props (tests.test_asyncsender.TestSenderWithTimeout)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asyncsender.py", line 213, in test_simple_with_timeout_props
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asyncsender.py", line 194, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'

======================================================================
ERROR: test_simple (tests.test_asyncsender.TestSenderWithTimeoutAndCircular)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asyncsender.py", line 267, in test_simple
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asyncsender.py", line 248, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'

======================================================================
ERROR: test_simple (tests.test_asyncsender.TestSenderWithTimeoutMaxSizeNonCircular)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asyncsender.py", line 317, in test_simple
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_asyncsender.py", line 298, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'

======================================================================
ERROR: test_custom_field_fill_missing_fmt_key_is_true (tests.test_handler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 240, in test_custom_field_fill_missing_fmt_key_is_true
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 21, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: {'sample': 'value'}
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_custom_fmt (tests.test_handler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 66, in test_custom_fmt
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 21, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: {'sample': 'value'}
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_custom_fmt_with_format_style (tests.test_handler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 173, in test_custom_fmt_with_format_style
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 21, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: {'sample': 'value'}
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_custom_fmt_with_template_style (tests.test_handler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 197, in test_custom_fmt_with_template_style
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 21, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: {'sample': 'value'}
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_exception_message (tests.test_handler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 368, in test_exception_message
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 21, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: ERROR: it failed
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 363, in test_exception_message
    raise Exception('sample exception')
Exception: sample exception
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_exclude_attrs (tests.test_handler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 85, in test_exclude_attrs
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 21, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: {'sample': 'value'}
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_exclude_attrs_with_exclusion (tests.test_handler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 103, in test_exclude_attrs_with_exclusion
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 21, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: {'sample': 'value'}
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_exclude_attrs_with_extra (tests.test_handler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 121, in test_exclude_attrs_with_extra
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 21, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: Test with value 'test value'
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_format_dynamic (tests.test_handler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 150, in test_format_dynamic
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 21, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: Test with value 'test value'
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_json_encoded_message (tests.test_handler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 260, in test_json_encoded_message
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 21, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: {"key": "hello world!", "param": "value"}
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_json_encoded_message_without_json (tests.test_handler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 277, in test_json_encoded_message_without_json
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 21, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: {"key": "hello world!", "param": "value"}
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_non_string_dict_message (tests.test_handler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 350, in test_non_string_dict_message
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 21, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: {42: 'root'}
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_non_string_simple_message (tests.test_handler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 336, in test_non_string_simple_message
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 21, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: 42
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_number_string_simple_message (tests.test_handler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 322, in test_number_string_simple_message
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 21, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: 1
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_simple (tests.test_handler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 39, in test_simple
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 21, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: {'from': 'userA', 'to': 'userB'}
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_unstructured_formatted_message (tests.test_handler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 307, in test_unstructured_formatted_message
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 21, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: hello world, you!
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_unstructured_message (tests.test_handler.TestHandler)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 292, in test_unstructured_message
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_handler.py", line 21, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'
-------------------- >> begin captured logging << --------------------
fluent.test: INFO: hello world
--------------------- >> end captured logging << ---------------------

======================================================================
ERROR: test_decorator_simple (tests.test_sender.TestSender)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_sender.py", line 80, in test_decorator_simple
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_sender.py", line 62, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'

======================================================================
ERROR: test_emit_after_close (tests.test_sender.TestSender)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_sender.py", line 155, in test_emit_after_close
    data = self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'

======================================================================
ERROR: test_emit_error (tests.test_sender.TestSender)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_sender.py", line 145, in test_emit_error
    data = self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'

======================================================================
ERROR: test_nanosecond (tests.test_sender.TestSender)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_sender.py", line 94, in test_nanosecond
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_sender.py", line 62, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'

======================================================================
ERROR: test_nanosecond_coerce_float (tests.test_sender.TestSender)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_sender.py", line 109, in test_nanosecond_coerce_float
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_sender.py", line 62, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'

======================================================================
ERROR: test_simple (tests.test_sender.TestSender)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_sender.py", line 68, in test_simple
    data = self.get_data()
  File "/home/nilesh/ups/fluent-logger-python/tests/test_sender.py", line 62, in get_data
    return self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'

======================================================================
ERROR: test_unix_socket (tests.test_sender.TestSender)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/nilesh/ups/fluent-logger-python/tests/test_sender.py", line 306, in test_unix_socket
    data = self._server.get_received()
  File "/home/nilesh/ups/fluent-logger-python/tests/mockserver.py", line 71, in get_received
    return list(Unpacker(self._buf, encoding='utf-8'))
  File "msgpack/_unpacker.pyx", line 317, in msgpack._cmsgpack.Unpacker.__init__
TypeError: __init__() got an unexpected keyword argument 'encoding'

Name                     Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------
fluent/__init__.py           0      0      0      0   100%
fluent/asynchandler.py      16      0      0      0   100%
fluent/asyncsender.py       71      2     12      0    98%   9-10
fluent/event.py              8      0      0      0   100%
fluent/handler.py          127      0     36      0   100%
fluent/sender.py           154      0     40      0   100%
--------------------------------------------------------------------
TOTAL                      376      2     88      0    99%
----------------------------------------------------------------------
Ran 73 tests in 0.223s

FAILED (SKIP=2, errors=46)
```

After the change, it goes green:

```
$ python3 setup.py nosetests
running nosetests
running egg_info
writing fluent_logger.egg-info/PKG-INFO
writing dependency_links to fluent_logger.egg-info/dependency_links.txt
writing requirements to fluent_logger.egg-info/requires.txt
writing top-level names to fluent_logger.egg-info/top_level.txt
reading manifest template 'MANIFEST.in'
warning: no files found matching 'test/*py'
writing manifest file 'fluent_logger.egg-info/SOURCES.txt'
.................S................S......................................
Name                     Stmts   Miss Branch BrPart  Cover   Missing
--------------------------------------------------------------------
fluent/__init__.py           0      0      0      0   100%
fluent/asynchandler.py      16      0      0      0   100%
fluent/asyncsender.py       71      2     12      0    98%   9-10
fluent/event.py              8      0      0      0   100%
fluent/handler.py          127      0     36      0   100%
fluent/sender.py           154      0     40      0   100%
--------------------------------------------------------------------
TOTAL                      376      2     88      0    99%
----------------------------------------------------------------------
Ran 73 tests in 0.180s

OK (SKIP=2)
```