### PR TITLE
add discard_logs_on_reconnect_error in asyncsender

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /build
 /dist
 .idea/
+venv/
+env/

--- a/tests/test_asynchandler.py
+++ b/tests/test_asynchandler.py
@@ -13,8 +13,6 @@ try:
 except ImportError:
     from mock import patch
 
-
-
 import fluent.asynchandler
 import fluent.handler
 from tests import mockserver


### PR DESCRIPTION
issue: https://github.com/fluent/fluent-logger-python/issues/175

When using asyncsender, there is a queue holds the logs to be send:
- when except socket.gaierror, i clear the queue and print log
- this avoids the back of the log blocked when sent
- but the first one will inevitably have this problem
- i'm thinking about other methods, maybe just simply print some logs

This is my solution, it doesn’t look particularly good. so feel free to close this if un-needed