### PR TITLE
FluentSender: fix requirement for root tag per sender instance

### DIFF
--- a/fluent/sender.py
+++ b/fluent/sender.py
@@ -122,7 +122,7 @@ class FluentSender(object):
 
     def _make_packet(self, label, timestamp, data):
         if label:
-            tag = '.'.join((self.tag, label))
+            tag = '.'.join((self.tag, label)) if self.tag else label
         else:
             tag = self.tag
         packet = (tag, timestamp, data)


### PR DESCRIPTION
I want some messages to be generated with different tags, but for now i'm *forced* to use same root (prefix) tag for no reason per sender instance.
If I use `FluentSender('').emit('my_tag', data)` - I got `".my_tag"` tag instead of `"my_tag"`. This PR fixes this.