### PR TITLE
chore(python): update supported Python versions to 3.10 and above

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.9", "pypy3.10"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.10", "pypy3.11"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Python application.
 Requirements
 ------------
 
--  Python 3.7+
+-  Python 3.10+
 - ``msgpack``
 - **IMPORTANT**: Version 0.8.0 is the last version supporting Python 2.6, 3.2 and 3.3
 - **IMPORTANT**: Version 0.9.6 is the last version supporting Python 2.7 and 3.4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "A Python logging handler for Fluentd event collector"
 readme = "README.rst"
 license = { file = "COPYING" }
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 authors = [
     { name = "Kazuki Ohta", email = "kazuki.ohta@gmail.com" },
 ]
@@ -20,12 +20,11 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Topic :: System :: Logging",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 1.7.2
-envlist = py27, py32, py33, py34, py35, py36, py37, py38
+envlist = py310, py311, py312, py313, py314
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
Python 3.7 through 3.9 have reached their end of life and are no longer supported. This commit updates the supported Python versions to 3.10 and above, ensuring that the project remains compatible with the latest Python releases.